### PR TITLE
Fix: Discord Presence Timer Now Resets on Automatic Song Change

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -1,17 +1,25 @@
-// Enhanced content script for YouTube Music
+// Content script with force reset logic for automatic song changes
 let previousData = null;
-let resetNextUpdate = false;
+let currentSongId = null;
 const SERVER_URL = 'http://localhost:3000/update';
-const CHECK_INTERVAL = 1000; // Check every second
+const CHECK_INTERVAL = 500; // Check every 500ms
 
-// Enhanced song data extraction with additional error handling
+// Function to extract song information from YouTube Music
 function extractSongData() {
   try {
+    // Get video element for playback status
+    const videoElement = document.querySelector('video');
+    const isVideoAvailable = !!videoElement;
+    const isVideoPlaying = isVideoAvailable && 
+                           !videoElement.paused && 
+                           videoElement.currentTime > 0 &&
+                           !videoElement.ended;
+    
     // Get song title
     const songTitleElement = document.querySelector('.title.ytmusic-player-bar');
     const songTitle = songTitleElement ? songTitleElement.textContent.trim() : 'Unknown Song';
 
-    // Get artist name with improved parsing
+    // Get artist
     const artistElement = document.querySelector('.byline.ytmusic-player-bar');
     let artist = 'Unknown Artist';
     let album = '';
@@ -21,40 +29,16 @@ function extractSongData() {
       const separator = fullText.indexOf(' • ');
       
       if (separator !== -1) {
-        // Split artist and album if separator exists
         artist = fullText.substring(0, separator).trim();
         if (separator < fullText.length - 3) {
           album = fullText.substring(separator + 3).trim();
         }
       } else {
-        // Just artist, no album
         artist = fullText;
       }
     }
 
-    // Get video element for accurate playback info
-    const videoElement = document.querySelector('video');
-    let isPlaying = false;
-    let currentTime = '0:00';
-    let duration = '0:00';
-    
-    if (videoElement) {
-      // Check if actually playing (not paused and time is advancing)
-      isPlaying = !videoElement.paused && videoElement.currentTime > 0;
-      
-      // Format time values
-      const formatTime = (seconds) => {
-        if (!seconds || isNaN(seconds) || seconds < 0) return '0:00';
-        const mins = Math.floor(seconds / 60);
-        const secs = Math.floor(seconds % 60);
-        return `${mins}:${secs.toString().padStart(2, '0')}`;
-      };
-      
-      currentTime = formatTime(videoElement.currentTime);
-      duration = formatTime(videoElement.duration);
-    }
-
-    // Get album art URL - try to get higher resolution
+    // Get album art URL
     const artworkElement = document.querySelector('.image.ytmusic-player-bar');
     let albumArt = '';
     
@@ -62,28 +46,69 @@ function extractSongData() {
       albumArt = artworkElement.src.replace(/=w\d+-h\d+/, '=w480-h480');
     }
     
-    // Get the YouTube video ID for the song URL
+    // Get current time and duration
+    let currentTime = '0:00';
+    let duration = '0:00';
+    let rawCurrentTime = 0;
+    let rawDuration = 0;
+    
+    if (isVideoAvailable) {
+      rawCurrentTime = videoElement.currentTime;
+      rawDuration = videoElement.duration;
+      
+      const formatTime = (seconds) => {
+        if (!seconds || isNaN(seconds) || seconds < 0) return '0:00';
+        const mins = Math.floor(seconds / 60);
+        const secs = Math.floor(seconds % 60);
+        return `${mins}:${secs.toString().padStart(2, '0')}`;
+      };
+      
+      currentTime = formatTime(rawCurrentTime);
+      duration = formatTime(rawDuration);
+    }
+    
+    // Get video ID for song URL
     let songUrl = '';
     const videoId = new URLSearchParams(window.location.search).get('v');
     if (videoId) {
       songUrl = `https://music.youtube.com/watch?v=${videoId}`;
     } else {
-      // Try the URL path for mobile or alternative formats
       const pathMatch = window.location.pathname.match(/\/watch\/([a-zA-Z0-9_-]+)/);
       if (pathMatch && pathMatch[1]) {
         songUrl = `https://music.youtube.com/watch?v=${pathMatch[1]}`;
       }
     }
     
+    // Generate a unique ID for this song+time combination
+    // The goal is to force Discord to see this as a new activity when the song changes
+    const newSongId = `${songTitle}-${artist}-${Date.now()}`;
+    
+    // Check if song has changed
+    const songChanged = !currentSongId || 
+                        (previousData && 
+                         (previousData.songTitle !== songTitle || 
+                          previousData.artist !== artist));
+    
+    // Update song ID if changed
+    if (songChanged) {
+      console.log(`Song changed: "${previousData?.songTitle || ''}" → "${songTitle}"`);
+      currentSongId = newSongId;
+    }
+    
+    // Return complete song data
     return {
       songTitle,
       artist,
       album,
-      isPlaying,
+      isPlaying: isVideoPlaying,
       currentTime,
       duration,
       albumArt,
       songUrl,
+      rawCurrentTime,
+      rawDuration,
+      songId: currentSongId,
+      songChanged,
       timestamp: Date.now()
     };
   } catch (error) {
@@ -92,24 +117,19 @@ function extractSongData() {
   }
 }
 
-// Enhanced data sending with retry logic and timeout
+// Send data to server with retry
 function sendDataToLocalServer(data) {
   return new Promise((resolve, reject) => {
     console.log('Sending data to server:', data);
-    
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 5000); // 5 second timeout
     
     fetch(SERVER_URL, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify(data),
-      signal: controller.signal
+      body: JSON.stringify(data)
     })
     .then(response => {
-      clearTimeout(timeoutId);
       if (!response.ok) {
         throw new Error(`HTTP error! Status: ${response.status}`);
       }
@@ -120,64 +140,53 @@ function sendDataToLocalServer(data) {
       resolve(responseData);
     })
     .catch(error => {
-      clearTimeout(timeoutId);
       console.error('Error sending data to local server:', error);
-      reject(error);
+      
+      // Retry once
+      setTimeout(() => {
+        console.log('Retrying server connection...');
+        fetch(SERVER_URL, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify(data)
+        })
+        .then(response => response.json())
+        .then(responseData => {
+          console.log('Retry successful:', responseData);
+          resolve(responseData);
+        })
+        .catch(retryError => {
+          console.error('Retry failed:', retryError);
+          reject(retryError);
+        });
+      }, 1000);
     });
   });
 }
 
-// Detect significant changes that warrant an update
-function hasSignificantChanges(current, previous) {
-  // Force update if flag is set (for song changes)
-  if (resetNextUpdate) {
-    resetNextUpdate = false;
-    return true;
-  }
-  
+// Check if we should update Discord
+function shouldUpdateDiscord(current, previous) {
   // First update or missing data
   if (!previous) return true;
   
-  // Playing status changed
-  if (current.isPlaying !== previous.isPlaying) return true;
-  
   // Song changed
-  if (current.songTitle !== previous.songTitle || 
-      current.artist !== previous.artist) {
-    // Set flag to force another update on the next interval
-    // This helps ensure Discord gets the reset signal
-    resetNextUpdate = true;
+  if (current.songChanged) {
     return true;
   }
   
-  // Only check time progress if playing
+  // Playing status changed
+  if (current.isPlaying !== previous.isPlaying) {
+    return true;
+  }
+  
+  // For time updates, only send every ~15 seconds if playing
   if (current.isPlaying) {
-    const parseTimeToSeconds = (timeStr) => {
-      if (!timeStr) return 0;
-      const parts = timeStr.split(':').map(Number);
-      if (parts.length === 2) {
-        return parts[0] * 60 + parts[1]; // MM:SS format
-      } else if (parts.length === 3) {
-        return parts[0] * 3600 + parts[1] * 60 + parts[2]; // HH:MM:SS format
-      }
-      return 0;
-    };
+    const currentTimeInSeconds = Math.floor(current.rawCurrentTime);
+    const previousTimeInSeconds = Math.floor(previous.rawCurrentTime);
     
-    const currentTimeSeconds = parseTimeToSeconds(current.currentTime);
-    const previousTimeSeconds = parseTimeToSeconds(previous.currentTime);
-    const durationSeconds = parseTimeToSeconds(current.duration);
-    
-    // Update if:
-    // - Time jumped by more than 2 seconds (user skipped)
-    // - Near beginning (first few seconds)
-    // - Near end (last few seconds)
-    // - Every 10 seconds for regular updates
-    if (Math.abs(currentTimeSeconds - previousTimeSeconds) >= 2 ||
-        currentTimeSeconds < 3 || 
-        (durationSeconds > 0 && durationSeconds - currentTimeSeconds < 5) ||
-        Math.floor(currentTimeSeconds / 10) > Math.floor(previousTimeSeconds / 10)) {
-      return true;
-    }
+    return Math.floor(currentTimeInSeconds / 15) > Math.floor(previousTimeInSeconds / 15);
   }
   
   return false;
@@ -187,11 +196,12 @@ function hasSignificantChanges(current, previous) {
 async function checkAndSendData() {
   try {
     const currentData = extractSongData();
+    if (!currentData) return;
     
-    if (currentData && hasSignificantChanges(currentData, previousData)) {
-      console.log('Song data changed, sending update:', currentData);
+    if (shouldUpdateDiscord(currentData, previousData)) {
+      console.log('Update needed, sending to server');
       
-      // Update our tracking before sending to avoid race conditions
+      // Update our tracking before sending
       previousData = {...currentData};
       
       // Send data to server
@@ -208,81 +218,109 @@ const intervalId = setInterval(checkAndSendData, CHECK_INTERVAL);
 // Check immediately when the script loads
 checkAndSendData();
 
-// Add various event listeners for more responsive updates
-
-// Play/pause button clicks
-document.addEventListener('click', (event) => {
-  if (event.target.closest('.play-pause-button')) {
-    setTimeout(checkAndSendData, 100);
+// Set up video element mutation observer for song changes
+function setupVideoObserver() {
+  // Find and monitor the video element
+  const videoElement = document.querySelector('video');
+  if (videoElement) {
+    // Listen for the 'loadstart' event which often indicates a new song
+    videoElement.addEventListener('loadstart', () => {
+      console.log('Video loadstart event detected - likely a new song');
+      // Force null previous data to ensure update
+      previousData = null;
+      setTimeout(checkAndSendData, 500);
+    });
+    
+    // Listen for 'ended' event to detect end of songs
+    videoElement.addEventListener('ended', () => {
+      console.log('Video ended event detected');
+      // Force null previous data to ensure update for next song
+      previousData = null;
+      currentSongId = null;
+      setTimeout(checkAndSendData, 500);
+    });
+    
+    console.log('Video element listeners set up');
+  } else {
+    // Try again if video not found
+    setTimeout(setupVideoObserver, 1000);
   }
-});
+}
 
-// Seekbar/timeline changes
-document.addEventListener('mouseup', (event) => {
-  if (event.target.closest('.bar.ytmusic-player-bar')) {
-    setTimeout(checkAndSendData, 100);
-  }
-});
-
-// Auto-detect song changes through mutations in the player bar
-const setupMutationObserver = () => {
+// Setup DOM mutation observer for song changes
+function setupMutationObserver() {
+  // Track changes to player bar (titles, artwork, etc)
   const playerBar = document.querySelector('ytmusic-player-bar');
   if (playerBar) {
     const observer = new MutationObserver((mutations) => {
-      // Check if title or artist changed
-      const titleChanged = mutations.some(m => 
-        m.target.classList.contains('title') || 
-        m.target.querySelector('.title')
-      );
+      // Look for significant mutations that indicate song changes
+      const significantChange = mutations.some(mutation => {
+        // Title or artist changes
+        if (mutation.target.classList && 
+            (mutation.target.classList.contains('title') || 
+             mutation.target.classList.contains('byline'))) {
+          return true;
+        }
+        
+        // Image changes (album art)
+        if (mutation.target.tagName === 'IMG' || 
+            (mutation.target.querySelector && mutation.target.querySelector('img'))) {
+          return true;
+        }
+        
+        return false;
+      });
       
-      const artistChanged = mutations.some(m => 
-        m.target.classList.contains('byline') || 
-        m.target.querySelector('.byline')
-      );
-      
-      if (titleChanged || artistChanged) {
-        console.log('Detected song change through DOM mutation');
-        resetNextUpdate = true;
-        setTimeout(checkAndSendData, 100);
+      if (significantChange) {
+        console.log('Significant player bar change detected');
+        // Force null previous data and song ID to ensure update
+        previousData = null;
+        currentSongId = null;
+        setTimeout(checkAndSendData, 300);
       }
     });
     
-    observer.observe(playerBar, { 
-      subtree: true, 
+    observer.observe(playerBar, {
       childList: true,
-      characterData: true
+      subtree: true,
+      characterData: true,
+      attributes: true,
+      attributeFilter: ['src', 'style']
     });
     
-    console.log('Set up mutation observer for player bar');
+    console.log('Player bar mutation observer set up');
   } else {
-    // Try again if player bar not found yet
+    // Try again if player bar not found
     setTimeout(setupMutationObserver, 1000);
   }
-};
+}
 
-// Set up video element listeners
-const setupVideoListener = () => {
-  const videoElement = document.querySelector('video');
-  if (videoElement) {
-    ['play', 'pause', 'seeking', 'seeked', 'loadeddata', 'canplay'].forEach(event => {
-      videoElement.addEventListener(event, () => {
-        setTimeout(checkAndSendData, 100);
-      });
-    });
-    console.log('Added video element listeners');
-  } else {
-    // Try again if video element not found yet
-    setTimeout(setupVideoListener, 1000);
-  }
-};
-
-// Initialize observers and listeners
+// Initialize all observers
+setupVideoObserver();
 setupMutationObserver();
-setupVideoListener();
+
+// Set up click listeners for manual navigation
+document.addEventListener('click', (event) => {
+  // Check for next/previous button clicks
+  if (event.target.closest('.next-button') || 
+      event.target.closest('.previous-button')) {
+    console.log('Next/Previous button clicked');
+    // Force null previous data and song ID to ensure update
+    previousData = null;
+    currentSongId = null;
+    setTimeout(checkAndSendData, 300);
+  }
+  
+  // Check for timeline clicks
+  if (event.target.closest('.bar.ytmusic-player-bar')) {
+    console.log('Timeline clicked');
+    setTimeout(checkAndSendData, 200);
+  }
+});
 
 // Clean up on page unload
 window.addEventListener('beforeunload', () => {
   clearInterval(intervalId);
 });
 
-console.log('YouTube Music Discord Rich Presence extension loaded!');
+console.log('YouTube Music Discord Rich Presence extension loaded with force reset logic!');

--- a/local-server/server.js
+++ b/local-server/server.js
@@ -1,4 +1,4 @@
-// Completely revised server.js using the discord-rpc library for better compatibility
+// Server with complete reset logic for Discord Rich Presence
 require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
@@ -9,6 +9,9 @@ const path = require('path');
 // Load environment variables
 const CLIENT_ID = process.env.DISCORD_CLIENT_ID;
 const PORT = process.env.PORT || 3000;
+
+// Enable debug logging
+const DEBUG = true;
 
 // Validate required environment variables
 if (!CLIENT_ID) {
@@ -21,23 +24,25 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
-// Initialize the RPC client
+// Initialize Discord RPC
 const rpc = new DiscordRPC.Client({ transport: 'ipc' });
 let connected = false;
 let lastSongData = null;
+let activeSongId = null;
 
 // Connect to Discord
 async function connectDiscord() {
   if (connected) return;
   
   try {
-    // Register event handlers
+    // Set up ready handler
     rpc.on('ready', () => {
       console.log('Connected to Discord RPC!');
+      console.log('Application:', rpc.application);
       connected = true;
     });
     
-    // Login with client ID
+    // Login with application ID
     await rpc.login({ clientId: CLIENT_ID });
   } catch (error) {
     console.error('Failed to connect to Discord:', error);
@@ -46,7 +51,7 @@ async function connectDiscord() {
   }
 }
 
-// Function to format time string to seconds
+// Parse time string to seconds
 function timeStringToSeconds(timeStr) {
   if (!timeStr) return 0;
   
@@ -59,14 +64,17 @@ function timeStringToSeconds(timeStr) {
   return 0;
 }
 
-// Clear the Rich Presence when music is paused
+// Clear activity when paused
 async function clearActivity() {
   if (!connected) {
     await connectDiscord();
+    return;
   }
   
   try {
     console.log('Clearing Discord activity');
+    // Reset active song ID when clearing
+    activeSongId = null;
     await rpc.clearActivity();
   } catch (error) {
     console.error('Error clearing Discord activity:', error);
@@ -75,34 +83,63 @@ async function clearActivity() {
   }
 }
 
-// Update the Rich Presence with song information
+// Update activity with song information
 async function updateActivity(songData) {
   if (!connected) {
     await connectDiscord();
+    return;
   }
   
   try {
-    console.log('Updating Discord presence with song:', songData.songTitle);
+    // Check if this is a new song or first update
+    const songChanged = songData.songChanged === true || 
+                        songData.songId !== activeSongId;
     
-    // Calculate timestamps for the progress bar
+    if (songChanged) {
+      console.log(`Song changed - updating from "${activeSongId || 'none'}" to "${songData.songId}"`);
+      
+      // If we're changing songs, first clear the current activity
+      // This is critical for forcing Discord to reset the timer
+      if (activeSongId) {
+        console.log('Forcing activity clear before setting new song');
+        await rpc.clearActivity();
+        
+        // Small delay to ensure Discord processes the clear
+        await new Promise(resolve => setTimeout(resolve, 500));
+      }
+      
+      // Update our tracking
+      activeSongId = songData.songId;
+    }
+    
+    // Calculate timestamps for timeline
     const now = Date.now();
     let startTimestamp = now;
     let endTimestamp = null;
     
+    // If we have time info, calculate proper timestamps
     if (songData.currentTime && songData.duration) {
       const currentSeconds = timeStringToSeconds(songData.currentTime);
       const durationSeconds = timeStringToSeconds(songData.duration);
       
       if (durationSeconds > 0) {
-        // Calculate when the song started (now - how far we are into the song)
-        startTimestamp = now - (currentSeconds * 1000);
+        // Calculate when the song started based on current position
+        if (songData.rawCurrentTime) {
+          startTimestamp = now - (songData.rawCurrentTime * 1000);
+        } else {
+          startTimestamp = now - (currentSeconds * 1000);
+        }
+        
         // Calculate when the song will end
-        endTimestamp = now + ((durationSeconds - currentSeconds) * 1000);
+        if (songData.rawDuration) {
+          endTimestamp = startTimestamp + (songData.rawDuration * 1000);
+        } else {
+          endTimestamp = startTimestamp + (durationSeconds * 1000);
+        }
       }
     }
     
-    // Create the activity data
-    // Note: Using setActivity instead of updatePresence for consistent behavior
+    // Create activity object
     const activity = {
       details: songData.songTitle || 'Unknown Song',
       state: `by ${songData.artist || 'Unknown Artist'}`,
@@ -112,22 +149,30 @@ async function updateActivity(songData) {
       smallImageText: 'Playing',
       startTimestamp: Math.floor(startTimestamp / 1000),
       endTimestamp: endTimestamp ? Math.floor(endTimestamp / 1000) : undefined,
-      instance: false,
+      buttons: [
+        {
+          label: "Listen on YouTube Music",
+          url: songData.songUrl || "https://music.youtube.com"
+        }
+      ],
+      instance: false
     };
     
-    // Add buttons if we have a valid URL
-    if (songData.songUrl) {
-      activity.buttons = [
-        { label: "Listen on YouTube Music", url: songData.songUrl }
-      ];
+    if (DEBUG) {
+      console.log('Setting activity:', {
+        song: songData.songTitle,
+        artist: songData.artist,
+        songId: songData.songId,
+        startTime: new Date(startTimestamp).toISOString(),
+        endTime: endTimestamp ? new Date(endTimestamp).toISOString() : 'none'
+      });
     }
     
-    console.log('Setting activity data:', activity);
-    
-    // Update Discord Rich Presence
+    // Set the activity
     await rpc.setActivity(activity);
   } catch (error) {
     console.error('Error updating Discord activity:', error);
+    console.error('Error details:', error.message);
     connected = false;
     await connectDiscord();
   }
@@ -135,43 +180,49 @@ async function updateActivity(songData) {
 
 // Main handler for presence updates
 async function updatePresence(songData) {
-  // Track if song has changed from last update
-  const songChanged = !lastSongData || 
-                    lastSongData.songTitle !== songData.songTitle || 
-                    lastSongData.artist !== songData.artist;
-  
-  // Update with activity or clear based on playback state
-  if (songData.isPlaying) {
-    await updateActivity(songData);
-  } else {
-    await clearActivity();
+  try {
+    // Handle based on playback state
+    if (songData.isPlaying) {
+      await updateActivity(songData);
+    } else {
+      await clearActivity();
+    }
+    
+    // Update last song data
+    lastSongData = {...songData};
+    
+    return true;
+  } catch (error) {
+    console.error('Error in updatePresence:', error);
+    return false;
   }
-  
-  // Store the last song data for comparison
-  lastSongData = {...songData};
-  
-  return songChanged;
 }
 
-// Handle extension requests
+// Route to receive updates from the browser extension
 app.post('/update', async (req, res) => {
   const songData = req.body;
-  console.log('Received song data:', songData);
+  console.log(`Received update: ${songData.songTitle} by ${songData.artist}`);
   
   try {
-    // Update Discord Rich Presence
-    const songChanged = await updatePresence(songData);
+    // Process song changes
+    if (songData.songChanged) {
+      console.log('Song change flag detected from extension');
+    }
     
-    // Send response with song change status
+    // Update Discord presence
+    await updatePresence(songData);
+    
+    // Send response
     res.json({ 
       status: 'success',
-      songChanged: songChanged
+      activeSongId: activeSongId,
+      songChanged: songData.songChanged
     });
   } catch (error) {
     console.error('Error in update endpoint:', error);
     res.status(500).json({ 
       status: 'error',
-      message: error.message
+      message: error.message 
     });
   }
 });
@@ -181,11 +232,71 @@ app.get('/status', (req, res) => {
   res.json({
     status: 'running',
     connected: connected,
-    currentSong: lastSongData
+    currentSong: lastSongData,
+    activeSongId: activeSongId
   });
 });
 
-// Simple homepage
+// Debug endpoints
+app.post('/reset', async (req, res) => {
+  console.log('Manual reset requested');
+  
+  try {
+    // Clear current activity
+    await rpc.clearActivity();
+    activeSongId = null;
+    
+    // Wait briefly
+    await new Promise(resolve => setTimeout(resolve, 500));
+    
+    // Set activity again if we have song data
+    if (lastSongData && lastSongData.isPlaying) {
+      await updatePresence({...lastSongData, songChanged: true});
+    }
+    
+    res.json({
+      status: 'success',
+      message: 'Discord activity reset'
+    });
+  } catch (error) {
+    console.error('Error during manual reset:', error);
+    res.status(500).json({
+      status: 'error',
+      message: error.message
+    });
+  }
+});
+
+app.post('/force-disconnect', async (req, res) => {
+  try {
+    console.log('Forcing Discord RPC disconnect');
+    
+    // Clear activity and destroy client
+    if (connected) {
+      await rpc.clearActivity();
+      rpc.destroy();
+    }
+    
+    connected = false;
+    activeSongId = null;
+    
+    // Reconnect after a brief delay
+    setTimeout(connectDiscord, 2000);
+    
+    res.json({
+      status: 'success',
+      message: 'Discord RPC disconnected and will reconnect'
+    });
+  } catch (error) {
+    console.error('Error during forced disconnect:', error);
+    res.status(500).json({
+      status: 'error',
+      message: error.message
+    });
+  }
+});
+
+// Home page
 app.get('/', (req, res) => {
   res.send(`
     <html>
@@ -194,12 +305,24 @@ app.get('/', (req, res) => {
         <style>
           body { font-family: Arial, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; }
           pre { background: #f4f4f4; padding: 10px; border-radius: 5px; }
+          .status { margin-top: 20px; }
+          button { padding: 8px 16px; background: #738ADB; color: white; border: none; border-radius: 4px; cursor: pointer; margin-right: 10px; }
+          button:hover { background: #5865F2; }
         </style>
       </head>
       <body>
         <h1>YouTube Music Discord Rich Presence</h1>
-        <p>Server is running. Check your Discord profile to see your music status.</p>
-        <pre id="status">Loading...</pre>
+        <p>Server with complete reset logic is running.</p>
+        
+        <div class="status">
+          <h2>Current Status</h2>
+          <pre id="status">Loading...</pre>
+        </div>
+        
+        <div style="margin-top: 20px;">
+          <button id="resetButton">Force Reset</button>
+          <button id="disconnectButton">Force Disconnect</button>
+        </div>
         
         <script>
           async function updateStatus() {
@@ -212,6 +335,29 @@ app.get('/', (req, res) => {
             }
             setTimeout(updateStatus, 5000);
           }
+          
+          document.getElementById('resetButton').addEventListener('click', async () => {
+            try {
+              const response = await fetch('/reset', { method: 'POST' });
+              const data = await response.json();
+              alert('Reset: ' + data.message);
+              updateStatus();
+            } catch (error) {
+              alert('Error: ' + error);
+            }
+          });
+          
+          document.getElementById('disconnectButton').addEventListener('click', async () => {
+            try {
+              const response = await fetch('/force-disconnect', { method: 'POST' });
+              const data = await response.json();
+              alert('Disconnect: ' + data.message);
+              updateStatus();
+            } catch (error) {
+              alert('Error: ' + error);
+            }
+          });
+          
           updateStatus();
         </script>
       </body>
@@ -221,7 +367,7 @@ app.get('/', (req, res) => {
 
 // Start the server
 app.listen(PORT, async () => {
-  console.log(`YouTube Music Discord Rich Presence server running on port ${PORT}`);
+  console.log(`Discord RPC server running on port ${PORT}`);
   await connectDiscord();
 });
 


### PR DESCRIPTION
**Description**:
This PR addresses a bug where the Discord Rich Presence timer would continue from the previous song when a new song started automatically (e.g., at the end of a track in YouTube Music).

**Fix Details**:

* Added logic to detect when a track has changed, regardless of whether it's user-initiated or automatic.
* On detecting a change, the presence is now fully updated, including the start timestamp.
* Ensures consistency in Discord's displayed song duration and progress.

**Tested Scenarios**:

* ✅ Song manually skipped → Timer resets correctly
* ✅ Song ends and next plays automatically → Timer resets correctly
* ✅ Pausing and resuming → No timer desync

**Closes**: #1 

